### PR TITLE
Remove unnecessary mappings

### DIFF
--- a/awesome/workloads/chrome.yaml
+++ b/awesome/workloads/chrome.yaml
@@ -34,5 +34,5 @@ hostAccess:
   # - ${HOME}/Downloads:/home/chrome/Downloads
   # - ${HOME}/.config/google-chrome:/home/chrome/.config/google-chrome
 
-  usbDevices:
-  - YubiKey # mount YubiKey
+  # usbDevices:
+  # - YubiKey # mount YubiKey

--- a/awesome/workloads/cli.yaml
+++ b/awesome/workloads/cli.yaml
@@ -6,7 +6,6 @@ singleInstance: true
 
 hostAccess:
   paths:
-  - ${GITDIR}/shared/homedir/.config/alacritty:/home/coder/.config/alacritty:ro
   - ${GITDIR}/shared/homedir/.gitconfig:/home/coder/.gitconfig:ro
   - ${GITDIR}/shared/homedir/.gitignore:/home/coder/.gitignore:ro
   - ${HOME}/git:/home/coder/git

--- a/awesome/workloads/cli.yaml
+++ b/awesome/workloads/cli.yaml
@@ -8,8 +8,6 @@ hostAccess:
   paths:
   - ${GITDIR}/shared/homedir/.gitconfig:/home/coder/.gitconfig:ro
   - ${GITDIR}/shared/homedir/.gitignore:/home/coder/.gitignore:ro
-  - ${HOME}/git:/home/coder/git
-  - ${HOME}/go:/home/coder/go
 
-  usbDevices:
-  - YubiKey
+  # usbDevices:
+  # - YubiKey

--- a/awesome/workloads/code.yaml
+++ b/awesome/workloads/code.yaml
@@ -18,5 +18,3 @@ hostAccess:
   - ${GITDIR}/shared/homedir/.gitconfig:/home/coder/.gitconfig:ro
   - ${GITDIR}/shared/homedir/.gitignore:/home/coder/.gitignore:ro
   - ${GITDIR}/shared/homedir/.config/Code:/home/coder/.config/Code
-  - ${HOME}/git:/home/coder/git
-  - ${HOME}/go:/home/coder/go

--- a/i3/workloads/chrome.yaml
+++ b/i3/workloads/chrome.yaml
@@ -34,5 +34,5 @@ hostAccess:
   # - ${HOME}/Downloads:/home/chrome/Downloads
   # - ${HOME}/.config/google-chrome:/home/chrome/.config/google-chrome
 
-  usbDevices:
-  - YubiKey # mount YubiKey
+  # usbDevices:
+  # - YubiKey # mount YubiKey

--- a/i3/workloads/cli.yaml
+++ b/i3/workloads/cli.yaml
@@ -6,7 +6,6 @@ singleInstance: true
 
 hostAccess:
   paths:
-  - ${GITDIR}/shared/homedir/.config/alacritty:/home/coder/.config/alacritty:ro
   - ${GITDIR}/shared/homedir/.gitconfig:/home/coder/.gitconfig:ro
   - ${GITDIR}/shared/homedir/.gitignore:/home/coder/.gitignore:ro
   - ${HOME}/git:/home/coder/git

--- a/i3/workloads/cli.yaml
+++ b/i3/workloads/cli.yaml
@@ -8,8 +8,6 @@ hostAccess:
   paths:
   - ${GITDIR}/shared/homedir/.gitconfig:/home/coder/.gitconfig:ro
   - ${GITDIR}/shared/homedir/.gitignore:/home/coder/.gitignore:ro
-  - ${HOME}/git:/home/coder/git
-  - ${HOME}/go:/home/coder/go
 
-  usbDevices:
-  - YubiKey
+  # usbDevices:
+  # - YubiKey

--- a/i3/workloads/code.yaml
+++ b/i3/workloads/code.yaml
@@ -18,5 +18,3 @@ hostAccess:
   - ${GITDIR}/shared/homedir/.gitconfig:/home/coder/.gitconfig:ro
   - ${GITDIR}/shared/homedir/.gitignore:/home/coder/.gitignore:ro
   - ${GITDIR}/shared/homedir/.config/Code:/home/coder/.config/Code
-  - ${HOME}/git:/home/coder/git
-  - ${HOME}/go:/home/coder/go

--- a/qubesome.config
+++ b/qubesome.config
@@ -30,7 +30,6 @@ profiles:
         - ${GITDIR}/shared/homedir/.local/share/applications:/home/xorg-user/.local/share/applications:ro
         - ${GITDIR}/shared/homedir/.local/share/pixmaps:/home/xorg-user/.local/share/pixmaps:ro
         - ${GITDIR}/awesome/homedir/.config/awesome:/home/xorg-user/.config/awesome
-        - ${HOME}/git:/data/git
         - ${HOME}/Downloads:/data/Downloads
 
     i3:
@@ -64,5 +63,4 @@ profiles:
         - ${GITDIR}/shared/homedir/.local/share/applications:/home/xorg-user/.local/share/applications:ro
         - ${GITDIR}/i3/homedir/.config:/home/xorg-user/.config
         - ${GITDIR}/i3/homedir/.local/share/fonts:/home/xorg-user/.local/share/fonts:ro
-        - ${HOME}/git:/data/git
         - ${HOME}/Downloads:/data/Downloads


### PR DESCRIPTION
Stop mapping dirs that users may not have in their machines, to avoid unnecessary warning / error messages.